### PR TITLE
Added sleeps and process titles to prevent CPU thrashing and ease debugging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ venv
 
 #The joust.conf will change with a different username
 conf/supervisor/conf.d/joust.conf
+.vscode/settings.json
+.sonarlint/connectedMode.json

--- a/controller_process.py
+++ b/controller_process.py
@@ -1,6 +1,7 @@
 from games import game, joust_non_stop, werewolf, zombie, commander, tournament, speed_bomb, fight_club
 import common, piparty
 import logging
+import setproctitle
 
 logger = logging.getLogger(__name__)
 
@@ -9,6 +10,9 @@ logger = logging.getLogger(__name__)
 def main_track_move(menu, restart, move_serial, move_num, menu_opts, game_opts, force_color, battery, dead_count, game_mode, \
                     team, team_color_enum, sensitivity, dead_move, invincible_move, music_speed, show_team_colors, red_on_kill,\
                     revive, kill_proc):
+
+    # Set the process title
+    setproctitle.setproctitle(f"JoustMania-main_track_move({move_serial})")
 
     move = common.get_move(move_serial, move_num)
 

--- a/controller_process.py
+++ b/controller_process.py
@@ -2,8 +2,12 @@ from games import game, joust_non_stop, werewolf, zombie, commander, tournament,
 import common, piparty
 import logging
 import setproctitle
+import time
 
 logger = logging.getLogger(__name__)
+
+# Avoid spinning while game startup/instructions hold restart high.
+RESTART_SLEEP_SECS = 0.05
 
 #this should all be refactored to use the same options per game
 #this file is used for multiprocessing
@@ -19,7 +23,7 @@ def main_track_move(menu, restart, move_serial, move_num, menu_opts, game_opts, 
     while not kill_proc.value:
         move.set_rumble(0)
         if restart.value == 1:
-            pass
+            time.sleep(RESTART_SLEEP_SECS)
         elif menu.value == 1:
             logger.debug("Tracking Move (Menu): {}".format(move_serial))
             piparty.track_move(move_serial, move_num, move, menu_opts, force_color, battery, dead_count, restart, menu, kill_proc)

--- a/games/commander.py
+++ b/games/commander.py
@@ -8,6 +8,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Commander has its own intro input loop before generic tracking.
+INTRO_POLL_SLEEP_SECS = 0.002
+
 # Commander Opts
 class Opts(Enum):
     INTRO = 0
@@ -280,6 +283,7 @@ class Joust(Game):
                 else:
                     move.set_leds(*COMMANDER_COLORS[team].value)
             move.update_leds()
+            time.sleep(INTRO_POLL_SLEEP_SECS)
 
         opts[Opts.HOLDING.value] = False
         opts[Opts.SELECTION.value] = Selection.NOTHING.value

--- a/games/game.py
+++ b/games/game.py
@@ -425,10 +425,12 @@ class Game():
                 
             self.handle_status()
             self.check_end_game()
-            
 
             if self.game_end:
                 self.end_game()
+
+            #Give up 10ms to prevent CPU thrashing
+            time.sleep(0.01)            
 
         self.stop_tracking_moves()
 
@@ -587,3 +589,6 @@ class Game():
                 move.set_leds(*Colors.Black.value)
                 move.update_leds()
                 move.set_rumble(0)
+                
+            #Give up 10ms to prevent CPU thrashing
+            time.sleep(0.01)

--- a/games/game.py
+++ b/games/game.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 SLOW_MUSIC_SPEED = 1.0
 #this was 0.5
 FAST_MUSIC_SPEED = 1.3
+# Small real sleeps cap CPU without the old 10-30ms gameplay lag.
+GAME_LOOP_SLEEP_SECS = 0.002
+MOVE_TRACK_SLEEP_SECS = 0.001
 
 # The min and max timeframe in seconds for
 # the speed change to trigger, randomly selected
@@ -429,8 +432,8 @@ class Game():
             if self.game_end:
                 self.end_game()
 
-            # Yield CPU to prevent thrashing without adding fixed latency
-            os.sched_yield()
+            # Cap this hot loop with a short real sleep; sched_yield still busy-spins.
+            time.sleep(GAME_LOOP_SLEEP_SECS)
 
         self.stop_tracking_moves()
 
@@ -569,6 +572,8 @@ class Game():
                     if not invincible_move.value:
                         if change > threshold and time.time() > no_rumble:
                             dead_move.value = Status.DIED.value
+                            # Let the DIED branch send red/rumble before the main loop consumes it.
+                            continue
 
                         elif not vibrate and change > warning and time.time() > no_rumble:
                             vibrate = True
@@ -590,5 +595,5 @@ class Game():
                 move.update_leds()
                 move.set_rumble(0)
                 
-            # Yield CPU to prevent thrashing without adding fixed latency
-            os.sched_yield()
+            # Keep controller tracking responsive while preventing a full busy-spin.
+            time.sleep(MOVE_TRACK_SLEEP_SECS)

--- a/games/game.py
+++ b/games/game.py
@@ -429,8 +429,8 @@ class Game():
             if self.game_end:
                 self.end_game()
 
-            #Give up 10ms to prevent CPU thrashing
-            time.sleep(0.01)            
+            # Yield CPU to prevent thrashing without adding fixed latency
+            os.sched_yield()
 
         self.stop_tracking_moves()
 
@@ -590,5 +590,5 @@ class Game():
                 move.update_leds()
                 move.set_rumble(0)
                 
-            #Give up 10ms to prevent CPU thrashing
-            time.sleep(0.01)
+            # Yield CPU to prevent thrashing without adding fixed latency
+            os.sched_yield()

--- a/kill_processes.sh
+++ b/kill_processes.sh
@@ -3,4 +3,4 @@
 #this is for development purposes only, to stop the automattically
 #running piparty scripts
 sudo supervisorctl stop joustmania
-sudo kill -9 $(ps aux | grep '[p]iparty' | awk '{print $2}')
+sudo kill -9 $(ps aux | grep 'JoustMania-' | awk '{print $2}')

--- a/pacemanager.py
+++ b/pacemanager.py
@@ -63,6 +63,8 @@ class PaceManager:
 
     @common.async_print_exceptions
     async def run_(self):
+        import setproctitle
+        setproctitle.setproctitle(f"JoustMania-PaceManager")
         await asyncio.sleep(self.initial_pace_time_)
 
         pace = self.initial_pace_

--- a/piaudio.py
+++ b/piaudio.py
@@ -9,6 +9,8 @@ import scipy.signal as signal
 import pygame
 import random
 import glob
+import setproctitle
+
 from sys import platform
 if platform == "linux" or platform == "linux2":
     import alsaaudio
@@ -189,10 +191,13 @@ def audio_loop(fname, ratio, stop_proc):
                 wf.close()
                 device.close()
                 song_loaded = False
+        #Give up 500ms to prevent CPU thrashing
+        time.sleep(0.5)
 
 @functools.lru_cache(maxsize=128)
 class Audio:
     def __init__(self, fname):
+        setproctitle.setproctitle(f"JoustMania-Audio({fname})")
         #these are probably not necessary
         #segment = AudioSegment.from_file(fname)
         #buf = io.BytesIO()
@@ -224,6 +229,8 @@ class Audio:
 @functools.lru_cache(maxsize=16)
 class Music:
     def __init__(self, name):
+        setproctitle.setproctitle(f"JoustMania-Music({name})")
+    
         self.name = name
         self.transition_future_ = asyncio.Future()
 

--- a/piaudio.py
+++ b/piaudio.py
@@ -119,7 +119,8 @@ def audio_loop(fname, ratio, stop_proc):
     song_loaded = False
     while(True):
         if(stop_proc.value == 1):
-            pass
+            time.sleep(0.5)
+            continue
         elif(fname['song'] != ''):
             if(song_loaded == False):
                 try:

--- a/piparty.py
+++ b/piparty.py
@@ -12,6 +12,7 @@ from games import joust_ffa, joust_teams, joust_random_teams, joust_non_stop, tr
 from sys import platform
 from dotenv import find_dotenv, load_dotenv
 import logging.config
+import setproctitle
 
 if platform == "linux" or platform == "linux2":
     import jm_dbus
@@ -86,7 +87,7 @@ def track_move(serial, move_num, move, menu_opts, force_color, battery, dead_cou
     while True:
         if(restart.value == 1 or menu.value == 0 or kill_proc.value):
             return # Stop tracking move if restarting, exiting menu, or kill_procedures
-        time.sleep(0.01)
+
         # If there is a new event from the move
         if move.poll():
 
@@ -297,10 +298,14 @@ def track_move(serial, move_num, move, menu_opts, force_color, battery, dead_cou
             move.set_leds(*move_color)
         #Update colors
         move.update_leds()
-
+        
+        #Give up 30ms to prevent CPU thrashing
+        time.sleep(0.03)
+        
 class Menu():
     def __init__(self):
-
+        setproctitle.setproctitle(f"JoustMania-Menu()")
+        
         # Set up shared namespace between webserver and joustmania
         self.command_queue = Queue()
         self.joust_manager = Manager()
@@ -654,6 +659,8 @@ class Menu():
                 move_opt[Opts.STATUS.value] = Status.ALIVE.value #If move is not charging, set it to alive
 
     def game_loop(self):
+        import setproctitle
+        setproctitle.setproctitle(f"JoustMania-game_loop()")
         self.play_menu_music = True
         while True:
             # Only start the music the first loop
@@ -704,6 +711,9 @@ class Menu():
             self.check_command_queue()
             self.update_status('menu')
 
+            #Give up 30ms to prevent CPU thrashing
+            time.sleep(0.03)
+    
 
     def check_admin_controls(self):
         show_bat = False

--- a/piparty.py
+++ b/piparty.py
@@ -299,8 +299,8 @@ def track_move(serial, move_num, move, menu_opts, force_color, battery, dead_cou
         #Update colors
         move.update_leds()
         
-        #Give up 30ms to prevent CPU thrashing
-        time.sleep(0.03)
+        # Yield CPU to prevent thrashing without adding fixed latency
+        os.sched_yield()
         
 class Menu():
     def __init__(self):
@@ -711,8 +711,8 @@ class Menu():
             self.check_command_queue()
             self.update_status('menu')
 
-            #Give up 30ms to prevent CPU thrashing
-            time.sleep(0.03)
+            # Yield CPU to prevent thrashing without adding fixed latency
+            os.sched_yield()
     
 
     def check_admin_controls(self):

--- a/piparty.py
+++ b/piparty.py
@@ -50,6 +50,9 @@ TEAM_NUM = len(colors.team_color_list)
 
 SENSITIVITY_MODES = 5
 RANDOM_TEAM_SIZES = 6
+# Menu polling still needs tiny sleeps to avoid idle CPU spin.
+MENU_TRACK_SLEEP_SECS = 0.002
+MENU_LOOP_SLEEP_SECS = 0.01
 
 # Menu specific opts
 class Opts(Enum):
@@ -299,8 +302,8 @@ def track_move(serial, move_num, move, menu_opts, force_color, battery, dead_cou
         #Update colors
         move.update_leds()
         
-        # Yield CPU to prevent thrashing without adding fixed latency
-        os.sched_yield()
+        # Cap this polling loop without adding the larger latency that made menus sluggish.
+        time.sleep(MENU_TRACK_SLEEP_SECS)
         
 class Menu():
     def __init__(self):
@@ -711,8 +714,8 @@ class Menu():
             self.check_command_queue()
             self.update_status('menu')
 
-            # Yield CPU to prevent thrashing without adding fixed latency
-            os.sched_yield()
+            # Cap the menu loop while keeping admin controls responsive.
+            time.sleep(MENU_LOOP_SLEEP_SECS)
     
 
     def check_admin_controls(self):

--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,7 @@ setup() {
         libudev-dev swig libbluetooth-dev \
         alsa-utils alsa-tools libasound2-dev libsdl2-mixer-2.0-0 \
         python-dbus-dev python3-dbus libdbus-glib-1-dev usbutils libatlas-base-dev \
-        python3-pyaudio python3-psutil || exit -1
+        python3-pyaudio python3-psutil python3-setproctitle || exit -1
 
     echo "Installing PS move A.P.I. software updates"
     #install components for psmoveapi
@@ -55,7 +55,8 @@ setup() {
     PYTHON=$VENV/bin/python3
 
     echo "installing virtual environment dependencies"
-    $PYTHON -m pip install --ignore-installed flask Flask-WTF pyalsaaudio pydub pyyaml dbus-python python-dotenv setproctitle || exit -1
+
+    $PYTHON -m pip install --ignore-installed flask Flask-WTF pyalsaaudio pydub pyyaml dbus-python python-dotenv
 
     #Sometimes pygame tries to install without a whl, and fails (like 2.4.0) this
     #checks that only correct versions will install

--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,7 @@ setup() {
     PYTHON=$VENV/bin/python3
 
     echo "installing virtual environment dependencies"
-    $PYTHON -m pip install --ignore-installed flask Flask-WTF pyalsaaudio pydub pyyaml dbus-python python-dotenv || exit -1
+    $PYTHON -m pip install --ignore-installed flask Flask-WTF pyalsaaudio pydub pyyaml dbus-python python-dotenv setproctitle || exit -1
 
     #Sometimes pygame tries to install without a whl, and fails (like 2.4.0) this
     #checks that only correct versions will install

--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,7 @@ setup() {
     PYTHON=$VENV/bin/python3
 
     echo "installing virtual environment dependencies"
-    $PYTHON -m pip install --ignore-installed flask Flask-WTF pyalsaaudio pydub pyyaml dbus-python python-dotenv || exit -1
+    $PYTHON -m pip install --ignore-installed flask Flask-WTF pyalsaaudio pydub pyyaml dbus-python python-dotenv setproctitle || exit -1
 
     # audioop is not available on python >= 3.13
     $PYTHON -m pip install --ignore-installed audioop-lts || exit -1

--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,7 @@ setup() {
         libudev-dev swig libbluetooth-dev \
         alsa-utils alsa-tools libasound2-dev libsdl2-mixer-2.0-0 \
         python-dbus-dev python3-dbus libdbus-glib-1-dev usbutils libopenblas-dev \
-        python3-pyaudio python3-psutil || exit -1
+        python3-pyaudio python3-psutil python3-setproctitle || exit -1
 
     echo "Installing PS move A.P.I. software updates"
     #install components for psmoveapi
@@ -55,7 +55,8 @@ setup() {
     PYTHON=$VENV/bin/python3
 
     echo "installing virtual environment dependencies"
-    $PYTHON -m pip install --ignore-installed flask Flask-WTF pyalsaaudio pydub pyyaml dbus-python python-dotenv setproctitle || exit -1
+
+    $PYTHON -m pip install --ignore-installed flask Flask-WTF pyalsaaudio pydub pyyaml dbus-python python-dotenv
 
     # audioop is not available on python >= 3.13
     $PYTHON -m pip install --ignore-installed audioop-lts || exit -1

--- a/webui.py
+++ b/webui.py
@@ -207,6 +207,8 @@ class WebUI():
             return str(team_colors).replace("'",'"')#JSON is dumb and demands double quotes
 
 def start_web(command_queue, ns):
+    import setproctitle
+    setproctitle.setproctitle(f"JoustMania-WebUI")    
     webui = WebUI(command_queue,ns)
     webui.web_loop()
 


### PR DESCRIPTION
This is the pull request referenced in #310 and should resolve this bug.

Added `setproctitle()` calls to modules that create processes to aid in debugging. Used process titles `JoustMania-` with added context (e.g. module name, Controller MAC, audio file, etc.) This made figuring out which code was thrashing the CPU much easier, and showed the impact to changes clearly in HTOP.

Updated `kill_processes` to use the new process titles.

Added strategic `sleep()` calls to yield CPU in loops:
- `game.py`
  - 10ms `sleep` in `game_loop()`
  - 10ms `sleep` in `track_move()`
- `piaudio.py`
  - 500ms `sleep` in `Resample()` (audio plays from a sample buffer, so it can sleep quite a while between samples)
- `piparty.pi`
  - 30ms `sleep` in `track_move()`
  - 30ms `sleep` in game_loop()`
 
I set the sleep times based on experimentation to eliminate CPU throttling without compromising responsiveness.

Note all of my changes were tested only on a Raspberry Pi 4. I have not tested on Windows or other platforms.

Here is what HTOP looked like before these changes:
![Screen Shot 2023-08-07 at 10 20 50 AM](https://github.com/adangert/JoustMania/assets/11447445/2bdc57a8-91ce-40b2-87ed-f7041c2d7605)
Here is what HTOP looks like after these changes: 
<img width="1032" alt="Screenshot 2024-10-27 at 11 14 22 PM" src="https://github.com/user-attachments/assets/d2d65bac-3005-4575-aa39-4c6fedae4162">
