### PR TITLE
Update Windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ var/
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!piparty.spec
+!reset_psmove_connections.spec
 
 # Installer logs
 pip-log.txt
@@ -80,6 +82,7 @@ apfiles/ap_active
 
 # Python virtualenv
 venv
+.venv/
 
 #The joust.conf will change with a different username
 conf/supervisor/conf.d/joust.conf
@@ -88,3 +91,4 @@ conf/supervisor/conf.d/joust.conf
 psmove-baseline-*.json
 psmove-broker-*.json
 controller-manager-*.json
+steamworks/output/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ If you would not like to turn off the internal bluetooth (this is not recommende
 
 You can now disconnect the hdmi cable and run JoustMania in headless mode. JoustMania will automatically boot up on restart, menu music should start playing once the pi boots up. Note audio will only play out of HDMI when plugged into a monitor, and only out of the audio jack when unpluged from a monitor.
 
+Windows development build
+---------------------------
+
+For the complete Windows development, controller, packaging, testing, and
+build workflow, see the
+[Windows development and build guide](docs/windows/README.md).
+
+The Windows build uses Python 3.13, PyInstaller, and an adjacent current
+`psmoveapi` checkout. Build `psmoveapi` into its `build-hotplug` directory,
+then run:
+
+```
+py -3.13 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements-windows.txt
+pwsh -ExecutionPolicy Bypass -File .\build_windows.ps1
+```
+
+The standalone one-folder output is created in `dist\piparty`. It includes
+the Python runtime, web templates and static files, audio, `psmoveapi.dll`,
+`psmove.exe`, and the Windows controller-reset executable.
+
 Update Joust Mania
 ---------------------------
 Joustmania will auto update when started and connected to the internet. Sometimes there is a large update, it will say so, then you can press the start and select buttons on a controller to start this update, wait until the pi reboots. If you have the AP enabled, you may need to disable it first to gain access to the internet.
@@ -91,6 +112,16 @@ sudo ./reset_psmove_connections.sh
 
 This stops JoustMania, removes only PlayStation Move controllers, and starts
 JoustMania again.
+
+On Windows, first stop JoustMania, then open an Administrator PowerShell in
+the JoustMania directory.
+
+```
+.\reset_psmove_connections.ps1
+```
+
+The Windows reset removes only Bluetooth devices named `Motion Controller`
+and their matching PS Move virtual-cable registry entries.
 
 To list registered Move controllers, their model, assigned adapter, saved
 pairing state, and current connection state, run:

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -1,0 +1,61 @@
+[CmdletBinding()]
+param(
+    [string]$PSMoveRoot = '',
+    [string]$PSMoveBuild = ''
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not $PSMoveRoot) {
+    $PSMoveRoot = Join-Path (Split-Path -Parent $PSScriptRoot) 'psmoveapi'
+}
+$python = Join-Path $PSScriptRoot '.venv\Scripts\python.exe'
+if (-not (Test-Path -LiteralPath $python)) {
+    throw 'Create the Python 3.13 virtual environment and install requirements-windows.txt first.'
+}
+
+$pythonVersion = & $python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+if ($pythonVersion -ne '3.13') {
+    throw "The Windows build environment must use Python 3.13, not $pythonVersion."
+}
+
+if (-not $PSMoveBuild) {
+    $PSMoveBuild = Join-Path $PSMoveRoot 'build-hotplug'
+}
+
+$requiredInputs = @(
+    (Join-Path $PSMoveRoot 'bindings\python\psmoveapi.py'),
+    (Join-Path $PSMoveBuild 'psmoveapi.dll'),
+    (Join-Path $PSMoveBuild 'psmove.exe')
+)
+foreach ($requiredInput in $requiredInputs) {
+    if (-not (Test-Path -LiteralPath $requiredInput)) {
+        throw "Missing Windows build input: $requiredInput"
+    }
+}
+
+$env:PSMOVEAPI_ROOT = (Resolve-Path -LiteralPath $PSMoveRoot).Path
+$env:PSMOVEAPI_BUILD_DIR = (Resolve-Path -LiteralPath $PSMoveBuild).Path
+$env:PYGAME_HIDE_SUPPORT_PROMPT = '1'
+
+Push-Location $PSScriptRoot
+try {
+    & $python -m PyInstaller --clean --noconfirm `
+        --distpath 'build\windows-tools' `
+        --workpath 'build\reset-tool' `
+        'reset_psmove_connections.spec'
+    if ($LASTEXITCODE -ne 0) {
+        throw "Reset tool build failed with exit code $LASTEXITCODE."
+    }
+
+    & $python -m PyInstaller --clean --noconfirm `
+        --distpath 'dist' `
+        --workpath 'build\piparty' `
+        'piparty.spec'
+    if ($LASTEXITCODE -ne 0) {
+        throw "JoustMania build failed with exit code $LASTEXITCODE."
+    }
+} finally {
+    Pop-Location
+}
+
+Write-Host "Windows build complete: $PSScriptRoot\dist\piparty"

--- a/clear_devices.py
+++ b/clear_devices.py
@@ -1,8 +1,13 @@
-import jm_dbus
-import psmove_dbus
+"""Remove saved PS Move Bluetooth registrations from the local host."""
+
+import argparse
+import sys
 
 
-if __name__ == '__main__':
+def clear_linux_devices(dry_run=False):
+    import jm_dbus
+    import psmove_dbus
+
     hcis = jm_dbus.get_hci_dict().keys()
     removed = 0
     for hci in hcis:
@@ -12,10 +17,223 @@ if __name__ == '__main__':
         for dev in devices:
             proxy = jm_dbus.get_device_proxy(hci, dev)
             properties = jm_dbus.get_device_properties(proxy)
-            if psmove_dbus.is_psmove_device(properties):
-                address = str(jm_dbus.get_device_attrib(proxy, 'Address'))
-                print('Removing PS Move {} from {}'.format(address, hci))
-                jm_dbus.remove_device(hci, dev)
-                removed += 1
+            if not psmove_dbus.is_psmove_device(properties):
+                continue
 
-    print('Removed {} PS Move controller registration(s)'.format(removed))
+            address = str(jm_dbus.get_device_attrib(proxy, "Address"))
+            action = "Would remove" if dry_run else "Removing"
+            print("{} PS Move {} from {}".format(action, address, hci))
+            if not dry_run:
+                jm_dbus.remove_device(hci, dev)
+            removed += 1
+
+    return removed
+
+
+def clear_windows_devices(dry_run=False):
+    import ctypes
+    import winreg
+    from ctypes import wintypes
+
+    class BluetoothAddress(ctypes.Union):
+        _fields_ = [
+            ("value", ctypes.c_ulonglong),
+            ("bytes", ctypes.c_ubyte * 6),
+        ]
+
+    class BluetoothDeviceSearchParams(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", wintypes.DWORD),
+            ("fReturnAuthenticated", wintypes.BOOL),
+            ("fReturnRemembered", wintypes.BOOL),
+            ("fReturnUnknown", wintypes.BOOL),
+            ("fReturnConnected", wintypes.BOOL),
+            ("fIssueInquiry", wintypes.BOOL),
+            ("cTimeoutMultiplier", ctypes.c_ubyte),
+            ("hRadio", wintypes.HANDLE),
+        ]
+
+    class SystemTime(ctypes.Structure):
+        _fields_ = [
+            ("wYear", wintypes.WORD),
+            ("wMonth", wintypes.WORD),
+            ("wDayOfWeek", wintypes.WORD),
+            ("wDay", wintypes.WORD),
+            ("wHour", wintypes.WORD),
+            ("wMinute", wintypes.WORD),
+            ("wSecond", wintypes.WORD),
+            ("wMilliseconds", wintypes.WORD),
+        ]
+
+    class BluetoothDeviceInfo(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", wintypes.DWORD),
+            ("Address", BluetoothAddress),
+            ("ulClassofDevice", wintypes.ULONG),
+            ("fConnected", wintypes.BOOL),
+            ("fRemembered", wintypes.BOOL),
+            ("fAuthenticated", wintypes.BOOL),
+            ("stLastSeen", SystemTime),
+            ("stLastUsed", SystemTime),
+            ("szName", wintypes.WCHAR * 248),
+        ]
+
+    bluetooth = ctypes.WinDLL("BluetoothApis.dll", use_last_error=True)
+    bluetooth.BluetoothFindFirstDevice.argtypes = [
+        ctypes.POINTER(BluetoothDeviceSearchParams),
+        ctypes.POINTER(BluetoothDeviceInfo),
+    ]
+    bluetooth.BluetoothFindFirstDevice.restype = wintypes.HANDLE
+    bluetooth.BluetoothFindNextDevice.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(BluetoothDeviceInfo),
+    ]
+    bluetooth.BluetoothFindNextDevice.restype = wintypes.BOOL
+    bluetooth.BluetoothFindDeviceClose.argtypes = [wintypes.HANDLE]
+    bluetooth.BluetoothFindDeviceClose.restype = wintypes.BOOL
+    bluetooth.BluetoothRemoveDevice.argtypes = [ctypes.POINTER(BluetoothAddress)]
+    bluetooth.BluetoothRemoveDevice.restype = wintypes.DWORD
+
+    search = BluetoothDeviceSearchParams()
+    search.dwSize = ctypes.sizeof(search)
+    search.fReturnAuthenticated = True
+    search.fReturnRemembered = True
+    search.fReturnUnknown = True
+    search.fReturnConnected = True
+    search.fIssueInquiry = False
+    search.cTimeoutMultiplier = 1
+    search.hRadio = None
+
+    def new_device_info():
+        info = BluetoothDeviceInfo()
+        info.dwSize = ctypes.sizeof(info)
+        return info
+
+    def address_string(address):
+        return ":".join(
+            "{:02x}".format(address.bytes[index])
+            for index in range(5, -1, -1)
+        )
+
+    controllers = []
+    info = new_device_info()
+    find_handle = bluetooth.BluetoothFindFirstDevice(
+        ctypes.byref(search),
+        ctypes.byref(info),
+    )
+    if find_handle:
+        try:
+            while True:
+                if info.szName == "Motion Controller":
+                    native_address = BluetoothAddress()
+                    native_address.value = info.Address.value
+                    controllers.append((address_string(info.Address), native_address))
+
+                info = new_device_info()
+                if not bluetooth.BluetoothFindNextDevice(
+                    find_handle,
+                    ctypes.byref(info),
+                ):
+                    break
+        finally:
+            bluetooth.BluetoothFindDeviceClose(find_handle)
+
+    # The Windows pairing code marks each Move as virtually cabled under a key
+    # named <host Bluetooth address><controller Bluetooth address>. Match only
+    # keys ending in a controller address found through the Bluetooth API.
+    registry_base = (
+        r"SYSTEM\CurrentControlSet\Services\HidBth\Parameters\Devices"
+    )
+    controller_ids = {
+        address.replace(":", "").lower()
+        for address, _ in controllers
+    }
+    registry_keys = []
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            registry_base,
+            access=winreg.KEY_READ | winreg.KEY_WOW64_64KEY,
+        ) as devices_key:
+            index = 0
+            while True:
+                try:
+                    name = winreg.EnumKey(devices_key, index)
+                except OSError:
+                    break
+                if any(name.lower().endswith(device_id) for device_id in controller_ids):
+                    registry_keys.append(name)
+                index += 1
+    except FileNotFoundError:
+        pass
+
+    if not dry_run and not ctypes.windll.shell32.IsUserAnAdmin():
+        raise PermissionError(
+            "Windows PS Move reset must be run from Administrator PowerShell."
+        )
+
+    failures = []
+    error_not_found = 1168
+    action = "Would remove" if dry_run else "Removing"
+    for address, native_address in controllers:
+        print("{} PS Move Bluetooth registration {}".format(action, address))
+        if not dry_run:
+            result = bluetooth.BluetoothRemoveDevice(ctypes.byref(native_address))
+            if result == error_not_found:
+                # Windows can retain a device in the Bluetooth enumeration
+                # cache after its PnP registration has already disappeared.
+                print("PS Move {} was already absent".format(address))
+            elif result != 0:
+                failures.append(
+                    "BluetoothRemoveDevice({}) failed with Windows error {}".format(
+                        address,
+                        result,
+                    )
+                )
+
+    for name in registry_keys:
+        print("{} PS Move virtual-cable registry key {}".format(action, name))
+        if not dry_run:
+            try:
+                winreg.DeleteKeyEx(
+                    winreg.HKEY_LOCAL_MACHINE,
+                    registry_base + "\\" + name,
+                    access=winreg.KEY_WOW64_64KEY,
+                )
+            except OSError as error:
+                # BluetoothRemoveDevice can remove this key first.
+                if getattr(error, "winerror", None) != 2:
+                    failures.append(
+                        "Could not remove registry key {}: {}".format(name, error)
+                    )
+
+    if failures:
+        raise RuntimeError("\n".join(failures))
+
+    return len(controllers)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Remove saved PS Move Bluetooth registrations.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show registrations that would be removed without changing anything",
+    )
+    args = parser.parse_args()
+
+    if sys.platform.startswith("linux"):
+        removed = clear_linux_devices(args.dry_run)
+    elif sys.platform == "win32":
+        removed = clear_windows_devices(args.dry_run)
+    else:
+        raise SystemExit("PS Move registration reset is not supported on this OS")
+
+    verb = "Found" if args.dry_run else "Removed"
+    print("{} {} PS Move controller registration(s)".format(verb, removed))
+
+
+if __name__ == "__main__":
+    main()

--- a/conf/logging.prod.ini
+++ b/conf/logging.prod.ini
@@ -1,0 +1,35 @@
+[loggers]
+keys=root,file
+
+[handlers]
+keys=console,file
+
+[formatters]
+keys=console,file
+
+[logger_root]
+level=INFO
+handlers=console,file
+
+[logger_file]
+level=DEBUG
+handlers=file
+qualname=file
+
+[handler_console]
+class=StreamHandler
+level=INFO
+formatter=console
+args=(sys.stdout,)
+
+[handler_file]
+class=FileHandler
+level=DEBUG
+formatter=file
+args=('%(logfilename)s','a',)
+
+[formatter_console]
+format=%(asctime)s - %(levelname)s - %(name)s - %(message)s
+
+[formatter_file]
+format=%(asctime)s - %(levelname)s - %(name)s - %(funcName)s:%(lineno)d - %(message)s

--- a/controller_manager.py
+++ b/controller_manager.py
@@ -123,13 +123,37 @@ def _check_write_in_progress(manager, controller_index) -> bool:
 
 
 def _binding_paths():
-    """Returns paths into the adjacent PSMoveAPI checkout used by this module.
-    _api_process_main() loads the Python ctypes binding and native library from
-    these paths, while pair_controller() uses the build path for the upstream
-    pairing executable.
+    """Returns the ctypes binding, native library, and CLI directories.
+
+    Source runs default to the adjacent PSMoveAPI checkout and can override
+    each location with environment variables. Frozen runs load the DLL from
+    PyInstaller's runtime directory and launch the bundled CLI beside the main
+    executable.
     """
+    if getattr(sys, "frozen", False):
+        app_dir = Path(sys.executable).resolve().parent
+        runtime_dir = Path(getattr(sys, "_MEIPASS", app_dir)).resolve()
+        bindings = Path(
+            os.environ.get("PSMOVEAPI_BINDINGS_PATH", str(runtime_dir))
+        )
+        library = Path(
+            os.environ.get("PSMOVEAPI_LIBRARY_PATH", str(runtime_dir))
+        )
+        cli = Path(os.environ.get("PSMOVEAPI_CLI_PATH", str(app_dir)))
+        return bindings, library, cli
+
     checkout = Path(__file__).resolve().parent.parent / "psmoveapi"
-    return checkout / "bindings" / "python", checkout / "build"
+    bindings = Path(
+        os.environ.get(
+            "PSMOVEAPI_BINDINGS_PATH",
+            str(checkout / "bindings" / "python"),
+        )
+    )
+    library = Path(
+        os.environ.get("PSMOVEAPI_LIBRARY_PATH", str(checkout / "build"))
+    )
+    cli = Path(os.environ.get("PSMOVEAPI_CLI_PATH", str(library)))
+    return bindings, library, cli
 
 
 def _api_process_main(manager):
@@ -143,7 +167,7 @@ def _api_process_main(manager):
     """
     # The delayed import keeps the ctypes binding and libpsmoveapi.so inside
     # the API process. Other JoustMania processes only use shared state.
-    bindings, library = _binding_paths()
+    bindings, library, _ = _binding_paths()
     if str(bindings) not in sys.path:
         sys.path.insert(0, str(bindings))
     os.environ.setdefault("PSMOVEAPI_LIBRARY_PATH", str(library))
@@ -154,7 +178,7 @@ def _api_process_main(manager):
         manager.status["error"] = repr(error)
         manager.ready_event.set()
         raise RuntimeError(
-            "Could not load the current PSMove API ctypes binding. Run setup.sh first."
+            "Could not load the current PSMove API ctypes binding and native library."
         ) from error
 
     local_controller_indices = {}
@@ -337,8 +361,9 @@ def get_manager_process_pid():
 
 def pair_controller(host_address):
     """Pairs USB controllers with the selected host using the upstream CLI."""
-    _, build = _binding_paths()
-    command = [str(build / "psmove"), "pair"]
+    _, _, cli = _binding_paths()
+    executable = "psmove.exe" if sys.platform.startswith("win") else "psmove"
+    command = [str(cli / executable), "pair"]
     environment = os.environ.copy()
     if host_address:
         # Tell PSMoveAPI to pair with the least-loaded adapter selected by JoustMania.

--- a/docs/windows/README.md
+++ b/docs/windows/README.md
@@ -1,0 +1,389 @@
+# JoustMania Windows Development and Build Guide
+
+This guide records the complete Windows workflow used on July 16, 2026. It
+covers development setup, the current PSMoveAPI integration, running from
+source, controller pairing, packaging, and testing.
+
+## Current repository state
+
+The working checkouts are sibling directories:
+
+```text
+<repository parent>\
+|-- JoustMania\
+`-- psmoveapi\
+```
+
+Choose any repository parent directory. Set these PowerShell variables to the
+locations on the current machine before using the commands in this guide:
+
+```powershell
+$reposRoot = 'C:\path\to\your\repositories'
+$joustRoot = Join-Path $reposRoot 'JoustMania'
+$psmoveRoot = Join-Path $reposRoot 'psmoveapi'
+```
+
+The variables last for the current PowerShell window. Set them again after
+opening a new window.
+
+The active branches used for the Windows build are:
+
+```text
+JoustMania: windows-modernization
+psmoveapi:  windows-hotplug
+```
+
+Both repositories currently contain important local Windows changes. Before
+pulling, switching branches, cleaning, or deleting build directories, inspect
+both repositories:
+
+```powershell
+git -C $joustRoot status
+git -C $psmoveRoot status
+```
+
+Do not use `git reset --hard`, `git clean`, or delete either checkout until the
+Windows changes have been committed or otherwise backed up.
+
+The repository remotes are:
+
+```text
+JoustMania origin: https://github.com/adangert/JoustMania.git
+psmoveapi origin:  https://github.com/adangert/psmoveapi.git
+psmoveapi upstream: https://github.com/thp/psmoveapi.git
+```
+
+## Required software
+
+Install the following on a 64-bit Windows 10 or Windows 11 machine:
+
+1. Git for Windows.
+2. Python 3.13, 64-bit, including the Python launcher.
+3. Visual Studio 2022 Community.
+4. The Visual Studio workload named **Desktop development with C++**.
+5. MSVC v143, a current Windows 10 or Windows 11 SDK, and CMake tools for
+   Windows from the Visual Studio Installer.
+6. PowerShell 7, recommended for the build command.
+7. A Bluetooth adapter supported by Windows and a data-capable USB cable for
+   each PlayStation Move controller.
+
+Confirm Python:
+
+```powershell
+py -3.13 --version
+```
+
+The successful setup used Python 3.13.14. The Windows package is intentionally
+pinned to Python 3.13 because the build script checks that version.
+
+## Visual Studio and CMake
+
+The current PSMoveAPI build uses the Visual Studio 2022 generator. The CMake
+executable bundled with Visual Studio is a reliable choice:
+
+```powershell
+$psmoveCmake = 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe'
+& $psmoveCmake --version
+```
+
+An older standalone CMake installation may not know the `Visual Studio 17
+2022` generator. It does not have to be uninstalled. Use the full Visual
+Studio CMake path shown above.
+
+If MSBuild reports that `Microsoft.TeamTest.targets` is malformed or has a
+missing root element, repair Visual Studio 2022 in Visual Studio Installer,
+then apply available updates.
+
+## Build the current PSMoveAPI
+
+Open an ordinary PowerShell for compilation. Administrator access is not
+needed to configure or build.
+
+```powershell
+Set-Location $psmoveRoot
+
+$psmoveCmake = 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe'
+
+& $psmoveCmake --fresh -S . -B build-hotplug -G 'Visual Studio 17 2022' -A x64 `
+  -DPSMOVE_BUILD_TRACKER=OFF `
+  -DPSMOVE_BUILD_EXAMPLES=OFF `
+  -DPSMOVE_BUILD_NAVCON_TEST=OFF `
+  -DPSMOVE_USE_SIXPAIR=OFF
+
+& $psmoveCmake --build build-hotplug --config Release --parallel
+```
+
+The Windows packaging workflow requires these outputs:
+
+```text
+psmoveapi\build-hotplug\psmove.exe
+psmoveapi\build-hotplug\psmoveapi.dll
+psmoveapi\bindings\python\psmoveapi.py
+```
+
+The `windows-hotplug` branch also contains the local Windows device-monitoring
+implementation. That code is what lets JoustMania notice USB and Bluetooth
+connection changes while the game is already running.
+
+## Pair and inspect controllers with PSMoveAPI
+
+Pairing changes Windows Bluetooth state, so pairing must run from an
+Administrator PowerShell.
+
+1. Connect the Move controller with a data-capable USB cable.
+2. Open PowerShell as Administrator.
+3. Run:
+
+```powershell
+Set-Location (Join-Path $psmoveRoot 'build-hotplug')
+.\psmove.exe pair
+```
+
+4. Follow the prompt to unplug the controller.
+5. Press the PS button until the status light remains on.
+6. Inspect connected controllers:
+
+```powershell
+.\psmove.exe list
+```
+
+A successful Bluetooth connection is reported as `Bluetooth` with a battery
+percentage. A magnetometer calibration warning does not prevent JoustMania
+from using the controller.
+
+JoustMania can also pair automatically. Start JoustMania as Administrator,
+then connect a Move controller by USB while it is running.
+
+## Create the Python environment
+
+Use the repository-local virtual environment. This avoids conflicts with
+unrelated global Python packages.
+
+```powershell
+Set-Location $joustRoot
+py -3.13 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install --upgrade pip
+.\.venv\Scripts\python.exe -m pip install -r requirements-windows.txt
+.\.venv\Scripts\python.exe -m pip check
+```
+
+Activation is optional because every command in this guide calls the virtual
+environment's Python directly.
+
+If PowerShell blocks activation or another local script, allow scripts only
+for the current PowerShell process:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+```
+
+## Run JoustMania from source
+
+Open PowerShell as Administrator. Administrator access is recommended because
+JoustMania listens on port 80 and can pair Bluetooth controllers.
+
+```powershell
+Set-Location $joustRoot
+
+$env:PYTHONPATH = Join-Path $psmoveRoot 'bindings\python'
+$env:PSMOVEAPI_LIBRARY_PATH = Join-Path $psmoveRoot 'build-hotplug'
+
+.\.venv\Scripts\python.exe .\piparty.py
+```
+
+The current source also detects a sibling `psmoveapi` checkout automatically,
+but setting the two environment variables makes the selected binding and DLL
+explicit.
+
+Expected behavior:
+
+- The console reports that piparty is starting.
+- Audio starts without requiring ffmpeg on Windows.
+- Flask starts on port 80.
+- The web interface is available at `http://localhost/`.
+- A Bluetooth controller is added to the menu.
+- A USB controller is detected and paired while the program is running.
+- Disconnecting and reconnecting a paired controller does not require a full
+  JoustMania restart.
+
+Stop the source process with `Ctrl+C` after testing.
+
+## Run the unit tests
+
+The current non-hardware controller tests use the current PSMoveAPI paths:
+
+```powershell
+Set-Location $joustRoot
+
+$env:PYTHONPATH = Join-Path $psmoveRoot 'bindings\python'
+$env:PSMOVEAPI_LIBRARY_PATH = Join-Path $psmoveRoot 'build-hotplug'
+
+.\.venv\Scripts\python.exe -m unittest -v test_controller test_game_controller_capacity
+```
+
+The verified result on July 16, 2026 was 8 passing tests.
+
+## Reset saved Move controller connections
+
+Stop JoustMania before resetting controllers.
+
+From a source checkout, open an Administrator PowerShell and run:
+
+```powershell
+Set-Location $joustRoot
+powershell -NoProfile -ExecutionPolicy Bypass -File .\reset_psmove_connections.ps1
+```
+
+From the packaged build, run this as Administrator:
+
+```text
+reset_psmove_connections.exe
+```
+
+The reset utility removes only Bluetooth devices named `Motion Controller`
+and matching PS Move virtual-cable registry entries. Windows error 1168 means
+a requested device registration was already absent and is treated as a safe
+condition by the current utility.
+
+After a reset, pair each controller again by USB.
+
+## Build the Windows distribution
+
+Make sure PSMoveAPI was built into `build-hotplug` and the Python virtual
+environment is complete. Then run:
+
+```powershell
+Set-Location $joustRoot
+pwsh -NoProfile -ExecutionPolicy Bypass -File .\build_windows.ps1
+```
+
+The build script performs two PyInstaller builds:
+
+1. `reset_psmove_connections.spec` builds the standalone administrator reset
+   tool from `clear_devices.py`.
+2. `piparty.spec` builds the main one-folder JoustMania distribution.
+
+The output is:
+
+```text
+JoustMania\dist\piparty\
+```
+
+Important files and directories in the output include:
+
+```text
+piparty.exe
+psmove.exe
+psmoveapi.dll
+reset_psmove_connections.exe
+audio\
+conf\logging.prod.ini
+static\
+templates\
+```
+
+`conf\logging.prod.ini` is required. The packaged executable selects it for
+production logging. Do not remove it from the source or packaged output.
+
+`joustsettings.yaml` is intentionally not packaged. A fresh default settings
+file is generated on first launch. Local settings are not embedded into new
+packages.
+
+Runtime logs are written to the package's `logs` directory and are excluded
+from build inputs.
+
+## Smoke test the packaged build
+
+Run the packaged executable as Administrator:
+
+```powershell
+Set-Location $joustRoot
+Start-Process -FilePath '.\dist\piparty\piparty.exe' -Verb RunAs
+```
+
+Verify all of the following:
+
+1. The administrator prompt appears.
+2. The application reaches the controller menu.
+3. `http://localhost/` returns the web interface.
+4. Audio plays.
+5. A controller can pair by USB after startup.
+6. A paired controller can reconnect over Bluetooth.
+7. Two or more controllers can be active at once.
+8. A complete game round starts, ends, and returns to the menu.
+9. The reset executable starts with an administrator prompt.
+
+The PyInstaller analysis may report an optional SciPy hidden import named
+`scipy.special._cdflib`. The July 16 build passed the application, audio, web,
+and controller smoke tests despite that warning.
+
+## Important developer files
+
+- `build_windows.ps1`: validates Python and PSMoveAPI, then runs both
+  PyInstaller builds.
+- `requirements-windows.txt`: pinned Python 3.13 Windows dependencies.
+- `piparty.spec`: main one-folder PyInstaller package definition.
+- `reset_psmove_connections.spec`: standalone administrator reset-tool package
+  definition.
+- `reset_psmove_connections.ps1`: source checkout wrapper for the reset tool.
+- `clear_devices.py`: cross-platform controller registration cleanup logic.
+- `conf\logging.prod.ini`: required production logging configuration.
+- `controller_manager.py`: shared controller state and PSMoveAPI process.
+
+## Troubleshooting
+
+### CMake cannot create the Visual Studio 17 2022 generator
+
+An old CMake executable is first on `PATH`. Use the full Visual Studio 2022
+CMake path documented above.
+
+### MSBuild cannot load Microsoft.TeamTest.targets
+
+Repair Visual Studio 2022 through Visual Studio Installer, then update it.
+
+### ImportError while loading `_psmove`
+
+The process is finding the old SWIG binding or a DLL with missing
+dependencies. Use the current ctypes binding in `bindings\python`, point
+`PSMOVEAPI_LIBRARY_PATH` to `build-hotplug`, and use the 64-bit Python 3.13
+environment.
+
+### ModuleNotFoundError for Flask, pygame, or another Python package
+
+Install `requirements-windows.txt` into `.venv` and run `.venv`'s Python, not
+a global Python installation.
+
+### ModuleNotFoundError for dbus on Windows
+
+Use the Windows modernization branch. The current Windows path does not import
+Linux DBus support.
+
+### PowerShell says running scripts is disabled
+
+Use one of these forms:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+powershell -NoProfile -ExecutionPolicy Bypass -File .\reset_psmove_connections.ps1
+```
+
+### A controller keeps blinking and never stays connected
+
+1. Stop JoustMania.
+2. Run the reset utility as Administrator.
+3. Connect the controller by USB.
+4. Pair it again as Administrator.
+5. Unplug it and press the PS button.
+6. Confirm it with `psmove.exe list`.
+
+### PyAudio reports error -9999
+
+Confirm Windows has a working default output device, close applications using
+the device exclusively, and restart JoustMania. The current Windows build does
+not require ffmpeg for its WAV playback path.
+
+### The web interface does not load
+
+Confirm JoustMania is still running, approve the administrator prompt, and open
+`http://localhost/`. Check that `templates`, `static`, and
+`conf\logging.prod.ini` exist beside the packaged executable.

--- a/pair.py
+++ b/pair.py
@@ -2,7 +2,6 @@ import controller_manager
 import os
 
 from sys import platform
-print(platform)
 if platform == "linux" or platform == "linux2":
     import jm_dbus
 elif platform == "windows" or platform == "win32":

--- a/piaudio.py
+++ b/piaudio.py
@@ -3,9 +3,12 @@ import wave
 import functools
 import io
 import numpy
-import psutil, os
+import os
+import psutil
 import time
 import scipy.signal as signal
+
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
 import pygame
 import random
 import glob
@@ -14,9 +17,9 @@ import setproctitle
 from sys import platform
 if platform == "linux" or platform == "linux2":
     import alsaaudio
+    from pydub import AudioSegment
 else:
     import pyaudio
-from pydub import AudioSegment
 from multiprocessing import Process, Value, Array, Queue, Manager
 
 import common

--- a/piparty.py
+++ b/piparty.py
@@ -1,16 +1,53 @@
+import os
+from pathlib import Path
+import sys
+
+
+if getattr(sys, "frozen", False):
+    APP_DIR = Path(sys.executable).resolve().parent
+    RUNTIME_DIR = Path(getattr(sys, "_MEIPASS", APP_DIR)).resolve()
+    os.environ.setdefault("PSMOVEAPI_LIBRARY_PATH", str(RUNTIME_DIR))
+    os.environ.setdefault("PSMOVEAPI_BINDINGS_PATH", str(RUNTIME_DIR))
+else:
+    APP_DIR = Path(__file__).resolve().parent
+    RUNTIME_DIR = APP_DIR
+    psmove_checkout = APP_DIR.parent / "psmoveapi"
+    psmove_bindings = psmove_checkout / "bindings" / "python"
+    psmove_build = psmove_checkout / "build-hotplug"
+    if not psmove_build.is_dir():
+        psmove_build = psmove_checkout / "build"
+    if psmove_bindings.is_dir():
+        sys.path.insert(0, str(psmove_bindings))
+        os.environ.setdefault("PSMOVEAPI_BINDINGS_PATH", str(psmove_bindings))
+    if psmove_build.is_dir():
+        os.environ.setdefault("PSMOVEAPI_LIBRARY_PATH", str(psmove_build))
+        os.environ.setdefault("PSMOVEAPI_CLI_PATH", str(psmove_build))
+
+# JoustMania's audio, settings, templates, and logging paths are relative to
+# the application directory. Steam is not required to choose that directory
+# as the process working directory, so establish it before importing modules.
+os.chdir(APP_DIR)
+
+# PyInstaller worker processes must be dispatched before importing modules
+# that configure logging or initialize native libraries.
+if __name__ == "__main__" and sys.platform.startswith("win"):
+    from multiprocessing import freeze_support as _freeze_support
+
+    _freeze_support()
+
 import controller_manager
 import common, colors, webui
 from colors import Colors
 from common import Button, Games, Status, Sensitivity
 import yaml
-import time, random, os, os.path
+import time, random, os.path
 from datetime import datetime
 from piaudio import Music, Audio, InitAudio
 from enum import Enum
-from multiprocessing import Process, Value, Array, Queue, Manager, freeze_support
+from multiprocessing import Process, Value, Array, Queue, Manager
 from games import joust_ffa, joust_teams, joust_random_teams, joust_non_stop, traitor, werewolf, zombie, commander, swapper, tournament, speed_bomb, fight_club
 from sys import platform
-from dotenv import find_dotenv, load_dotenv
+from dotenv import load_dotenv
 import logging.config
 import setproctitle
 
@@ -24,23 +61,25 @@ elif "win" in platform:
 import controller_process
 import update
 
-# find .env file in parent directory
-env_file = find_dotenv()
-load_dotenv()
+# Load the environment shipped beside the source or frozen executable.
+load_dotenv(APP_DIR / ".env")
+if getattr(sys, "frozen", False):
+    os.environ.setdefault("ENV", "prod")
 
-CONFIG_DIR = "./conf"
-LOG_DIR = "./logs"
+CONFIG_DIR = APP_DIR / "conf"
+LOG_DIR = APP_DIR / "logs"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 log_configs = {"dev": "logging.dev.ini", "prod": "logging.prod.ini"}
-config = log_configs.get(os.environ["ENV"], "logging.dev.ini")
-config_path = "/".join([CONFIG_DIR, config])
+config = log_configs.get(os.environ.get("ENV", "dev"), "logging.dev.ini")
+config_path = CONFIG_DIR / config
 
-timestamp = datetime.now().strftime("%Y%m%d-%H:%M:%S")
+timestamp = datetime.now().strftime("%Y%m%d-%H-%M-%S")
 
 logging.config.fileConfig(
-    config_path,
+    str(config_path),
     disable_existing_loggers=False,
-    defaults={"logfilename": f"{LOG_DIR}/{timestamp}.log"},
+    defaults={"logfilename": (LOG_DIR / f"{timestamp}.log").as_posix()},
 )
 
 logger = logging.getLogger(__name__)
@@ -848,6 +887,7 @@ class Menu():
 
     def initialize_settings(self):
         # Default settings
+        settings_loaded = False
         temp_settings = ({
             'sensitivity': Sensitivity.MID.value,
             'play_instructions': True,
@@ -875,6 +915,7 @@ class Menu():
             with open(common.SETTINGSFILE,'r') as yaml_file:
                 file_settings = yaml.safe_load(yaml_file)
             logger.debug(file_settings)
+            settings_loaded = True
 
             temp_colors = file_settings['color_lock_choices']
             for key in temp_colors.keys():
@@ -898,8 +939,10 @@ class Menu():
             temp_settings.update(file_settings)
             temp_settings['color_lock_choices'] = temp_colors
 
-        except Exception as e:
-            logger.error("We found an exception when loading the settings!", e)
+        except FileNotFoundError:
+            logger.info("No settings file found; creating one with defaults.")
+        except Exception:
+            logger.exception("Could not load the settings file; using defaults.")
 
         #force these settings
         temp_settings.update({
@@ -908,6 +951,8 @@ class Menu():
             'enforce_minimum': True
         })
         self.ns.settings = temp_settings
+        if not settings_loaded:
+            self.update_settings_file()
 
     def update_settings_file(self):
         with open(common.SETTINGSFILE,'w') as yaml_file:
@@ -1225,10 +1270,9 @@ class Menu():
 
 if __name__ == "__main__":
     logger.info("Starting piparty")
-    if "win" in platform:
-        freeze_support()
-    print("updating asound")
-    os.popen("sudo ./update_asound.sh")
+    if platform == "linux" or platform == "linux2":
+        print("updating asound")
+        os.popen("sudo ./update_asound.sh")
     print("starting audio")
     time.sleep(1)
     InitAudio()

--- a/piparty.spec
+++ b/piparty.spec
@@ -1,0 +1,85 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import os
+from pathlib import Path
+
+
+project_dir = Path(SPECPATH).resolve()
+psmove_root = Path(
+    os.environ.get("PSMOVEAPI_ROOT", project_dir.parent / "psmoveapi")
+).resolve()
+psmove_build = Path(
+    os.environ.get("PSMOVEAPI_BUILD_DIR", psmove_root / "build-hotplug")
+).resolve()
+psmove_bindings = psmove_root / "bindings" / "python"
+reset_executable = project_dir / "build" / "windows-tools" / "reset_psmove_connections.exe"
+
+required_inputs = [
+    psmove_bindings / "psmoveapi.py",
+    psmove_build / "psmoveapi.dll",
+    psmove_build / "psmove.exe",
+    reset_executable,
+]
+missing_inputs = [str(path) for path in required_inputs if not path.is_file()]
+if missing_inputs:
+    raise FileNotFoundError(
+        "Build the current PSMoveAPI and reset tool first. Missing:\n"
+        + "\n".join(missing_inputs)
+    )
+
+datas = [
+    (str(project_dir / "audio"), "audio"),
+    (str(project_dir / "conf"), "conf"),
+    (str(project_dir / "static"), "static"),
+    (str(project_dir / "templates"), "templates"),
+    (str(project_dir / "README.md"), "."),
+    (str(project_dir / "LICENSE"), "."),
+    (str(project_dir / "audio-license"), "."),
+    (str(project_dir / "clear_devices.py"), "."),
+    (str(project_dir / "reset_psmove_connections.ps1"), "."),
+]
+
+binaries = [
+    (str(psmove_build / "psmoveapi.dll"), "."),
+    (str(psmove_build / "psmove.exe"), "."),
+    (str(reset_executable), "."),
+]
+
+a = Analysis(
+    [str(project_dir / "piparty.py")],
+    pathex=[str(project_dir), str(psmove_bindings)],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=["psmoveapi"],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="piparty",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    uac_admin=True,
+    contents_directory=".",
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    name="piparty",
+)

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -1,0 +1,12 @@
+Flask==3.1.3
+Flask-WTF==1.3.0
+numpy==2.5.1
+psutil==7.2.2
+PyAudio==0.2.14
+pygame==2.6.1
+pyinstaller==6.21.0
+python-dotenv==1.2.2
+PyYAML==6.0.3
+scipy==1.18.0
+setproctitle==1.3.7
+WTForms==3.2.2

--- a/reset_psmove_connections.ps1
+++ b/reset_psmove_connections.ps1
@@ -1,0 +1,50 @@
+[CmdletBinding()]
+param(
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$clearDevices = Join-Path $scriptDirectory 'clear_devices.py'
+$resetExecutable = Join-Path $scriptDirectory 'reset_psmove_connections.exe'
+
+$joustProcesses = Get-CimInstance Win32_Process | Where-Object {
+    ($_.Name -in @('python.exe', 'pythonw.exe') -and
+        $_.CommandLine -match '(?i)(^|[\\/])piparty\.py(?:\s|$)') -or
+    $_.Name -eq 'piparty.exe'
+}
+
+if (-not $DryRun -and $joustProcesses) {
+    $processIds = ($joustProcesses.ProcessId -join ', ')
+    throw "Stop JoustMania before resetting controllers (running process IDs: $processIds)."
+}
+
+if (-not $DryRun) {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+    $isAdministrator = $principal.IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator
+    )
+    if (-not $isAdministrator) {
+        throw 'Run this script from an Administrator PowerShell window.'
+    }
+}
+
+$arguments = @()
+if ($DryRun) {
+    $arguments += '--dry-run'
+}
+
+if (Test-Path -LiteralPath $resetExecutable) {
+    & $resetExecutable @arguments
+} else {
+    $python = (Get-Command python.exe -ErrorAction Stop).Source
+    & $python $clearDevices @arguments
+}
+if ($LASTEXITCODE -ne 0) {
+    throw "PS Move reset failed with exit code $LASTEXITCODE."
+}
+
+if (-not $DryRun) {
+    Write-Host 'Reset complete. Start JoustMania and pair each controller again by USB.'
+}

--- a/reset_psmove_connections.spec
+++ b/reset_psmove_connections.spec
@@ -1,0 +1,36 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from pathlib import Path
+
+
+project_dir = Path(SPECPATH).resolve()
+
+a = Analysis(
+    [str(project_dir / "clear_devices.py")],
+    pathex=[str(project_dir)],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="reset_psmove_connections",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    uac_admin=True,
+)

--- a/webui.py
+++ b/webui.py
@@ -4,11 +4,16 @@ from flask import Flask, render_template, request, redirect, url_for, flash
 from time import sleep
 from wtforms import Form, SelectField, SelectMultipleField, BooleanField, widgets, FieldList
 from os import system
+from sys import platform
 import common, colors
 import json
 import yaml
 import logging
-import psmove_dbus
+
+if platform == "linux" or platform == "linux2":
+    import psmove_dbus
+else:
+    psmove_dbus = None
 
 log = logging.getLogger('werkzeug')
 log.setLevel(logging.ERROR)
@@ -121,7 +126,6 @@ class WebUI():
         return self.controller_debug()
 
     def controller_debug(self):
-        controllers = psmove_dbus.get_registered_controllers()
         battery_status = {
             str(address).upper(): level
             for address, level in dict(self.ns.battery_status).items()
@@ -130,6 +134,27 @@ class WebUI():
             str(address).upper(): value
             for address, value in dict(getattr(self.ns, 'out_moves', {})).items()
         }
+
+        if psmove_dbus is not None:
+            controllers = psmove_dbus.get_registered_controllers()
+        else:
+            # Windows has no BlueZ/D-Bus registry. Controllers reported by the
+            # game are already paired, loaded, and connected through psmoveapi.
+            controllers = [
+                {
+                    'adapter': 'Windows Bluetooth',
+                    'adapter_address': '',
+                    'address': address,
+                    'model': 'Unknown',
+                    'registered': True,
+                    'loaded': True,
+                    'paired': True,
+                    'connected': True,
+                    'trusted': True,
+                    'services_resolved': True,
+                }
+                for address in battery_status
+            ]
 
         for controller in controllers:
             address = controller['address'].upper()

--- a/win_pair.py
+++ b/win_pair.py
@@ -2,7 +2,6 @@ import controller_manager
 import os
 
 from sys import platform
-print(platform)
 if platform == "linux" or platform == "linux2":
     import jm_dbus
 elif "win" in platform:


### PR DESCRIPTION
## Summary

Updates JoustMania's Windows runtime and controller integration, adds a repeatable Python 3.13 and PyInstaller build, and includes pairing and reset tools plus Windows setup documentation.

This replaces the aging Python and PSMoveAPI setup and restores a complete standalone Windows package with current PsmoveAPI, audio, and web support.

## Validation

- 4 controllers tested and ran on Windows. (both types)
- Packaged executable tested with audio, web UI, pairing, reconnects, and a complete game round