### PR TITLE
Improve Steam Deck compatibility

### DIFF
--- a/proton_psmove.py
+++ b/proton_psmove.py
@@ -53,6 +53,29 @@ def _bundle_paths():
     )
 
 
+def _steam_library_dir():
+    """Return the Steam library that Proton maps to its S: game drive."""
+    install_path = os.environ.get("STEAM_COMPAT_INSTALL_PATH")
+    library_paths = os.environ.get("STEAM_COMPAT_LIBRARY_PATHS")
+    if not install_path or not library_paths:
+        return None
+
+    install_path = install_path.replace("\\", "/").rstrip("/")
+    matches = []
+    for library_path in library_paths.split(":"):
+        library_path = library_path.replace("\\", "/").rstrip("/")
+        if (
+            library_path
+            and (
+                install_path == library_path
+                or install_path.startswith(library_path + "/")
+            )
+        ):
+            matches.append(library_path)
+
+    return max(matches, key=len, default=None)
+
+
 def _unix_path(path):
     value = str(path).replace("\\", "/")
     if value.startswith("/"):
@@ -67,10 +90,18 @@ def _unix_path(path):
     if drive == "c" and os.environ.get("STEAM_COMPAT_DATA_PATH"):
         compat_data = os.environ["STEAM_COMPAT_DATA_PATH"].replace("\\", "/")
         return compat_data.rstrip("/") + "/pfx/drive_c/" + relative
+    if drive == "s":
+        library_dir = _steam_library_dir()
+        if library_dir:
+            return library_dir + "/" + relative
+        raise RuntimeError(
+            "Cannot resolve Proton S: drive without matching "
+            "STEAM_COMPAT_INSTALL_PATH and STEAM_COMPAT_LIBRARY_PATHS"
+        )
     raise RuntimeError(
-        "The Proton helper must be on Wine drive Z: or C:, not "
+        "Cannot convert unsupported Wine drive "
         + drive.upper()
-        + ":"
+        + ": to a Linux path"
     )
 
 

--- a/runtime_platform.py
+++ b/runtime_platform.py
@@ -30,8 +30,8 @@ def is_proton():
 
 
 def default_web_port():
-    """Avoid Steam's CEF debugging port when running through Proton."""
-    return 8081 if is_proton() else 80
+    """Avoid SteamOS CEF debugging ports when running through Proton."""
+    return 8090 if is_proton() else 80
 
 
 def controller_pairing_notice():

--- a/runtime_platform.py
+++ b/runtime_platform.py
@@ -29,6 +29,11 @@ def is_proton():
     return is_windows() and bool(os.environ.get("STEAM_COMPAT_DATA_PATH"))
 
 
+def default_web_port():
+    """Avoid Steam's CEF debugging port when running through Proton."""
+    return 8081 if is_proton() else 80
+
+
 def controller_pairing_notice():
     """Return the startup pairing notice for Windows-compatible builds."""
     if is_proton():

--- a/test_proton_compatibility.py
+++ b/test_proton_compatibility.py
@@ -1,0 +1,77 @@
+import os
+import unittest
+from unittest import mock
+
+import proton_psmove
+import runtime_platform
+
+
+class ProtonPathTest(unittest.TestCase):
+    def test_converts_proton_game_drive_path(self):
+        environment = {
+            "STEAM_COMPAT_INSTALL_PATH": (
+                "/home/deck/.local/share/Steam/steamapps/common/JoustMania"
+            ),
+            "STEAM_COMPAT_LIBRARY_PATHS": (
+                "/mnt/external/SteamLibrary:"
+                "/home/deck/.local/share/Steam"
+            ),
+        }
+
+        with mock.patch.dict(os.environ, environment, clear=True):
+            result = proton_psmove._unix_path(
+                r"S:\steamapps\common\JoustMania\proton\psmoveapi\psmove"
+            )
+
+        self.assertEqual(
+            result,
+            (
+                "/home/deck/.local/share/Steam/steamapps/common/"
+                "JoustMania/proton/psmoveapi/psmove"
+            ),
+        )
+
+    def test_uses_longest_matching_library_path(self):
+        environment = {
+            "STEAM_COMPAT_INSTALL_PATH": (
+                "/mnt/games/SteamLibrary/steamapps/common/JoustMania"
+            ),
+            "STEAM_COMPAT_LIBRARY_PATHS": (
+                "/mnt/games:/mnt/games/SteamLibrary"
+            ),
+        }
+
+        with mock.patch.dict(os.environ, environment, clear=True):
+            result = proton_psmove._unix_path(
+                r"S:\steamapps\common\JoustMania\piparty.exe"
+            )
+
+        self.assertEqual(
+            result,
+            (
+                "/mnt/games/SteamLibrary/steamapps/common/"
+                "JoustMania/piparty.exe"
+            ),
+        )
+
+    def test_reports_missing_game_drive_environment(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Cannot resolve Proton S: drive",
+            ):
+                proton_psmove._unix_path(r"S:\steamapps\common\JoustMania")
+
+
+class ProtonWebPortTest(unittest.TestCase):
+    def test_uses_8081_by_default_under_proton(self):
+        with mock.patch.object(runtime_platform, "is_proton", return_value=True):
+            self.assertEqual(runtime_platform.default_web_port(), 8081)
+
+    def test_native_default_remains_port_80(self):
+        with mock.patch.object(runtime_platform, "is_proton", return_value=False):
+            self.assertEqual(runtime_platform.default_web_port(), 80)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_proton_compatibility.py
+++ b/test_proton_compatibility.py
@@ -64,9 +64,9 @@ class ProtonPathTest(unittest.TestCase):
 
 
 class ProtonWebPortTest(unittest.TestCase):
-    def test_uses_8081_by_default_under_proton(self):
+    def test_uses_8090_by_default_under_proton(self):
         with mock.patch.object(runtime_platform, "is_proton", return_value=True):
-            self.assertEqual(runtime_platform.default_web_port(), 8081)
+            self.assertEqual(runtime_platform.default_web_port(), 8090)
 
     def test_native_default_remains_port_80(self):
         with mock.patch.object(runtime_platform, "is_proton", return_value=False):

--- a/webui.py
+++ b/webui.py
@@ -22,7 +22,7 @@ log.setLevel(logging.ERROR)
 
 
 def web_port():
-    default_port = 8080 if runtime_platform.is_proton() else 80
+    default_port = runtime_platform.default_web_port()
     return int(environ.get("JOUSTMANIA_WEB_PORT", default_port))
 
 


### PR DESCRIPTION
## Summary
- Support Proton installs mapped through the Steam `S:` drive
- Use port 8090 under Proton to avoid SteamOS CEF debugging conflicts
- Add focused Proton compatibility tests

## Testing
- `python -m unittest test_proton_compatibility.py`